### PR TITLE
PeerDependency auth0 => auth0-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   },
   "peerDependencies": {
     "angular": "^1.5.8",
-    "auth0": "^7.2.0"
+    "auth0-js": "^7.2.0"
   }
 }


### PR DESCRIPTION
`auth0` does not have a version 7.2.0, but `auth0-js` does. This is most likely an error.