### PR TITLE
Add node compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/angular-auth0');
+module.exports = 'auth0.auth0';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-auth0",
   "version": "1.0.4",
   "description": "Auth0.js wrapper for Angular.js",
-  "main": "angular-auth0.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/auth0/angular-auth0.git"


### PR DESCRIPTION
This simple commit adds compatibility with node and therefore with webpack. I've tested this in webpack 1, and it appears to work just fine. 