### PR TITLE
support all auth0-js config parameters

### DIFF
--- a/angular-auth0.js
+++ b/angular-auth0.js
@@ -20,6 +20,7 @@
       this.callbackURL = config.callbackURL;
       this.responseType = config.responseType;
       this.responseMode = config.responseMode;
+      this.scope = config.scope;
     };
 
     this.$get = ["$rootScope", function($rootScope) {
@@ -29,7 +30,8 @@
         clientID: this.clientID,
         callbackURL: this.callbackURL,
         responseMode: this.responseMode,
-        responseType: this.responseType
+        responseType: this.responseType,
+        scope: this.scope
       });
       var auth0 = {};
       var functions = [];

--- a/angular-auth0.js
+++ b/angular-auth0.js
@@ -15,24 +15,12 @@
       if (!config) {
         throw new Error('clientID and domain must be provided to auth0');
       }
-      this.domain = config.domain;
-      this.clientID = config.clientID;
-      this.callbackURL = config.callbackURL;
-      this.responseType = config.responseType;
-      this.responseMode = config.responseMode;
-      this.scope = config.scope;
+      this.config = config;
     };
 
     this.$get = ["$rootScope", function($rootScope) {
 
-      var Auth0Js = new Auth0({
-        domain: this.domain,
-        clientID: this.clientID,
-        callbackURL: this.callbackURL,
-        responseMode: this.responseMode,
-        responseType: this.responseType,
-        scope: this.scope
-      });
+      var Auth0Js = new Auth0(this.config);
       var auth0 = {};
       var functions = [];
       for (var i in Auth0Js) {


### PR DESCRIPTION
The current version of `angular-auth0` does not support `scope` on init and will silently drop the configuration value. 

- See Auth0 code here: https://github.com/auth0/auth0.js/blob/v7/index.js#L164
- See commit https://github.com/gconnolly/angular-auth0/commit/192df9dea6715eb7f4da52a296d4f2023244ffd3

Rather than one-off supporting the scope configuration, it would be ideal to passthrough all configuration from the wrapper to the Auth0 constructor. This would also allow for the support of other Auth0 configuration:

- `audience`, `sendSDKClientInfo`, `useCordovaSocialPlugins`, `forceJSONP`: https://github.com/auth0/auth0.js/blob/v7/index.js#L148-L167