### PR TITLE
Version mismatch on angular auth0 3.0.0 with bower js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-auth0",
   "main": "dist/angular-auth0.js",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "dependencies": {
     "angular": "*",
     "auth0.js": "^9.0.0"


### PR DESCRIPTION
It appears the bower.json was missed when updating the version to 3.0.0